### PR TITLE
Fix/incorrect merge order for:  Refactory/constants

### DIFF
--- a/constants/constants.py
+++ b/constants/constants.py
@@ -1,0 +1,30 @@
+from pybricks.parameters import Port, Color, Direction
+from . import Graper, DrivingUnit
+from pybricks.hubs import EV3Brick
+
+class Ports:
+    # Motor Ports
+    MOTOR_GRAPPER = Port.A
+    MOTOR_DRIVE_LEFT = Port.C
+    MOTOR_DRIVE_RIGHT = Port.D
+
+    # Sensor Ports
+    TOUCH_SENSOR_PORT = Port.S2 # Linker Sensor
+    COLOR_SENSOR_PORT = Port.S3
+
+    # ToDo: Richtiger Sensor ???
+    GYRO_SENSOR_PORT = Port.S4
+
+
+class Movement:
+    WHEEL_DIAMETER = 55.5  # Durchmesser der Räder in mm
+    AXLE_TRACK = 104  # Abstand zwischen den Rädern in mm
+    MOTOR_LEFT = Ports.MOTOR_DRIVE_LEFT
+    MOTOR_RIGHT = Ports.MOTOR_DRIVE_RIGHT
+    DRIVE_SPEED = 200
+    TURN_SPEED = 100 
+
+class Sensors:
+    OBSTACLE_DISTANCE = 100  # Distanz in mm, um ein Hindernis zu erkennen
+
+# ToDo: class Colors?

--- a/demos/constant_demo.py
+++ b/demos/constant_demo.py
@@ -1,0 +1,8 @@
+from ..modules.robot import Robot
+from .constant_module_demo import ExampleModule
+
+robot = Robot()
+demoFunction = ExampleModule(robot)
+
+robot.ev3.speaker.beep()
+demoFunction.example()

--- a/demos/constant_module_demo.py
+++ b/demos/constant_module_demo.py
@@ -1,0 +1,10 @@
+from ..modules.robot import Robot
+
+class ExampleModule:
+    def __init__(self, robot: Robot):
+        self.robot = robot
+
+    def example(self):
+        self.robot.ev3.speaker.beep()
+        self.robot.driving_unit.startMoving()
+        self.robot.graper.detect_and_grap()

--- a/modules/robot.py
+++ b/modules/robot.py
@@ -3,7 +3,7 @@ from pybricks.ev3devices import (Motor, TouchSensor, ColorSensor,
                                  InfraredSensor, UltrasonicSensor, GyroSensor)
 from .grap import Graper
 from .drivingUnit import DrivingUnit
-from constants import Ports, Movement
+from ..constants.constants import Ports, Movement
 
 class Robot:
     """Roboter-Klasse, die den EV3-Roboter verwaltet.
@@ -11,7 +11,7 @@ class Robot:
     def __init__(self):
         self.ev3 = EV3Brick()
         self.driving_unit = DrivingUnit()
-        self.graper = Graper(motor_port=Ports.MOTOR_A, sensor_port=Ports.COLOR_SENSOR_PORT)
+        self.graper = Graper(motor_port=Ports.MOTOR_GRAPPER, sensor_port=Ports.COLOR_SENSOR_PORT)
 
         # Initialize sensors
         self.color_sensor = ColorSensor(Ports.COLOR_SENSOR_PORT)

--- a/modules/robot.py
+++ b/modules/robot.py
@@ -1,0 +1,19 @@
+from pybricks.hubs import EV3Brick
+from pybricks.ev3devices import (Motor, TouchSensor, ColorSensor,
+                                 InfraredSensor, UltrasonicSensor, GyroSensor)
+from .grap import Graper
+from .drivingUnit import DrivingUnit
+from constants import Ports, Movement
+
+class Robot:
+    """Roboter-Klasse, die den EV3-Roboter verwaltet.
+    """
+    def __init__(self):
+        self.ev3 = EV3Brick()
+        self.driving_unit = DrivingUnit()
+        self.graper = Graper(motor_port=Ports.MOTOR_A, sensor_port=Ports.COLOR_SENSOR_PORT)
+
+        # Initialize sensors
+        self.color_sensor = ColorSensor(Ports.COLOR_SENSOR_PORT)
+        self.gyro_sensor = GyroSensor(Ports.GYRO_SENSOR_PORT)
+        self.touch_sensor = TouchSensor(Ports.TOUCH_SENSOR_PORT)


### PR DESCRIPTION
The former PR's were merged in the wrong order, thus this code got lost.

[#2 Refactory/constants:](https://github.com/MCh2003/Lego-Project5/pull/2)
> ## Basic
> `constants/constants.py`: Implementation of constants for managing ports, distances ...
> 
> Class `Robot` which concludes:
> 
> * `EV3`
> * Custom Modules
>   
>   * `DrivingUnit`
>   * `Graper`
> * Sensors directly
>   
>   * `ColorSensor`
>   * `GyroSensor`
>   * `TouchSensor`
> 
> ## Demo
> [demos/constant_demo.py](demos/constant_demo.py) shows how the class `Roboter` should be used. It also includes a demonstration of the usage of a module (in this case [demos/constant_module_demo.py](demos/constant_module_demo.py)). In the module-demo you can also find how to properly pass a robot to a module:
> 
> ```python
> class ExampleModule:
>     def __init__(self, robot: Robot):
>         self.robot = robot
> ```
